### PR TITLE
Syntax error at line 517 of '/admin' fixed.

### DIFF
--- a/admin/class-agadyn-woo-twitter-admin.php
+++ b/admin/class-agadyn-woo-twitter-admin.php
@@ -514,7 +514,7 @@ class Agadyn_Woo_Twitter_Admin {
 
 		if (is_multisite()){
 		    //Grab all options
-		    $site_id = (int) (get_site())->blog_id;
+		    $site_id = int(get_site($this->blog_id));
 		    $options = get_site_option($this->plugin_name);
 		    $access_token = get_site_option( 'agadyn-woo-twitter'.'-access_token-'.$site_id);
 


### PR DESCRIPTION
I've attached the screenshot of the error that was preventing the plugin from being installed.
It was a **syntax error**, so I corrected the code.
![woocommerce plugin error 2](https://user-images.githubusercontent.com/11141249/33664730-ef72806a-da94-11e7-9abc-88296176c7f0.jpg)
